### PR TITLE
fix: correct default empty value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.0.0]() (2025-07-16)
+## [1.0.1]() (2025-07-16)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.0]() (2025-07-16)
+
+### Bug fixes
+
+* Fix the `node_selector` and `tolerations` variables for EFS CSI add-on default to empty values
+
 ## [1.0.0]() (2025-07-11)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module will create the components below
 ```hcl
 module "eks" {
   source  = "c0x12c/eks-cluster/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   region          = "us-west-2"
   environment     = "test"

--- a/variables.tf
+++ b/variables.tf
@@ -301,7 +301,7 @@ variable "coredns" {
   description = "Configuration for CoreDNS add-on"
   type = object({
     replica_count = optional(number, 1)
-    node_selector = optional(map(string), null)
+    node_selector = optional(map(string), {})
     tolerations = optional(list(object({
       key      = string
       operator = string
@@ -311,7 +311,7 @@ variable "coredns" {
   })
   default = {
     replica_count = 1
-    node_selector = null
+    node_selector = {}
     tolerations   = []
   }
 }
@@ -320,7 +320,7 @@ variable "efs_csi" {
   description = "Configuration for EFS CSI add-on"
   type = object({
     replica_count = optional(number, 1)
-    node_selector = optional(map(string), null)
+    node_selector = optional(map(string), {})
     tolerations = optional(list(object({
       key      = string
       operator = string
@@ -330,7 +330,7 @@ variable "efs_csi" {
   })
   default = {
     replica_count = 1
-    node_selector = null
+    node_selector = {}
     tolerations   = []
   }
 }


### PR DESCRIPTION
## Summary
Correct the default empty value of the plugins node selector

### Why
Currently using the module yields this error:
```
│ Error: updating EKS Add-On (paratus-health-eks-dev:coredns): operation error EKS: UpdateAddon, https response error StatusCode: 400, RequestID: b715f340-a69c-4f26-aa20-55f4f2c5c1e8, InvalidParameterException: ConfigurationValue provided in request is not supported: Json schema validation failed with error: [$.nodeSelector: null found, object expected]
```

### What
Update the default value of nodeSelector to `{}` instead of `null`

### Solution
<!--- Describe the architectural or design decisions you made while implementing the changes.
Explain the thought process behind your approach and how it aligns with best practices or existing patterns in the codebase. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
